### PR TITLE
fix: use assign/strong accordingly based on the platform flag

### DIFF
--- a/React/Base/RCTBridgeModule.h
+++ b/React/Base/RCTBridgeModule.h
@@ -129,7 +129,12 @@ RCT_CONCAT(initialize_, objc_name)() { RCTRegisterModule([objc_name class]); }
  * and the bridge will populate the methodQueue property for you automatically
  * when it initializes the module.
  */
+#if OS_OBJECT_SWIFT3 == 1
 @property (nonatomic, strong, readonly) dispatch_queue_t methodQueue;
+#else
+@property (nonatomic, assign, readonly) dispatch_queue_t methodQueue;
+#endif
+
 
 /**
  * Wrap the parameter line of your method implementation with this macro to


### PR DESCRIPTION
## Summary

Fixing compilation error: "Cross Platform compilation : property with 'retain (or strong)' attribute must be of object type" When importing "RCTBridgeModule.h "

## Changelog

[iOS] [Fixed] - tvos compilation error when importing "RCTBridgeModule.h"

## Test Plan

For tvos, import RCTBridgeModule in a new module and compile the code. 
