### PR TITLE
Make sure textInput views are not null

### DIFF
--- a/ReactAndroid/src/main/java/com/facebook/react/views/textinput/ReactTextInputManager.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/textinput/ReactTextInputManager.java
@@ -942,7 +942,7 @@ public class ReactTextInputManager extends BaseViewManager<ReactEditText, Layout
 
                     // manually triggering onFocusChanged when having only one input field on
                     // the screen and no other focusable elements
-                    if (editText.getId() == view.getId()) {
+                    if (editText != null && view != null && editText.getId() == view.getId()) {
                       editText.onFocusChanged(false, View.FOCUSABLES_ALL, null);
                     }
                     editText.hideKeyboard();


### PR DESCRIPTION
## Summary

Fixes null textInput fields error on Chromecast devices. that can occur when a text field is updated

## Changelog

Updates to ReactTextInputManager to check for null views

